### PR TITLE
fix: add coston2 to chain list

### DIFF
--- a/config/chains.ts
+++ b/config/chains.ts
@@ -29,4 +29,20 @@ export const chains: ChainMap<ChainMetadata> = {
       },
     ],
   },
+
+  coston2: {
+    name: 'coston2',
+    chainId: 114,
+    nativeToken: {
+      name: 'Coston2Flare',
+      symbol: 'C2FLR',
+      decimals: 18,
+    },
+    isTestnet: true,
+    publicRpcUrls: [
+      {
+        http: 'https://coston2-api.flare.network/ext/C/rpc',
+      },
+    ],
+  },
 };

--- a/config/multisig_ism.ts
+++ b/config/multisig_ism.ts
@@ -16,4 +16,9 @@ export const multisigIsmConfig: ChainMap<MultisigIsmConfig> = {
       '0xa0ee7a142d267c1f36714e4a8f75612f20a79720',
     ],
   },
+  coston2: {
+    threshold: 1,
+    // this is random address taken from explorer
+    validators: ['0x2F79Dce2375571207a7976148D4468195F89a73e'],
+  },
 };


### PR DESCRIPTION
For now just testing purpose I have added coston2 here but this will eventually come from `@ortege/sdk`